### PR TITLE
Fix various code generation issues

### DIFF
--- a/definitions/definitions.go
+++ b/definitions/definitions.go
@@ -35,7 +35,7 @@ func (q QFunc) GenFuncSignatureC(contractName string, addCallOpts bool) string {
 	var sigInParens []string
 
 	if addCallOpts {
-		sigInParens = append(sigInParens, []string{"UniversalAddress __address", "QtumCallOptions* __options"}...)
+		sigInParens = append(sigInParens, []string{"UniversalAddress *__address", "QtumCallOptions* __options"}...)
 	}
 	for _, input := range q.Inputs {
 		if isArray(input.Type) {
@@ -66,9 +66,15 @@ func (q QFunc) generateFuncCallSignatureC(contractName string) string {
 	var sig []string
 	for _, input := range q.Inputs {
 		sig = append(sig, input.TypeName)
+		if(isArray(input.Type)){
+			sig = append(sig, input.TypeName + "_sz");
+		}
 	}
 	for _, output := range q.Outputs {
-		sig = append(sig, "&"+output.TypeName)
+		sig = append(sig, "&" + output.TypeName)
+		if(isArray(output.Type)){
+			sig = append(sig, "&" + output.TypeName + "_sz");
+		}
 	}
 	return contractName + "_" + q.FuncName + "(" + strings.Join(sig, ", ") + ");"
 }

--- a/definitions/definitions.go
+++ b/definitions/definitions.go
@@ -61,9 +61,10 @@ func (q QFunc) GenFuncSignatureC(contractName string, isEncoding bool) string {
 	}
 	if isEncoding {
 		return contractName + "_" + q.FuncName + "(" + strings.Join(sigInParens, ", ") + ")"
-	}else{
-		return contractName + "_" + q.FuncName + "_dispatch" + "(" + strings.Join(sigInParens, ", ") + ")"
 	}
+	
+	return contractName + "_" + q.FuncName + "_dispatch" + "(" + strings.Join(sigInParens, ", ") + ")"
+	
 }
 
 func (q QFunc) generateFuncCallSignatureC(contractName string) string {

--- a/definitions/definitions.go
+++ b/definitions/definitions.go
@@ -136,7 +136,7 @@ func (typ QType) generateFuncCallBody() []string {
 	switch {
 	case isArray(typ.Type):
 		return []string{
-			fmt.Sprintf("\t*%v_sz = qtumItemSize();", typ.TypeName),
+			fmt.Sprintf("\t*%v_sz = qtumPeekSize();", typ.TypeName),
 			fmt.Sprintf("\t*%v = malloc(*%v_sz * sizeof(**%v));", typ.TypeName, typ.TypeName, typ.TypeName),
 			fmt.Sprintf("\t%v(*%v, *%v_sz * sizeof(**%v));", getQtumPopStatement(typ.Type), typ.TypeName, typ.TypeName, typ.TypeName),
 			fmt.Sprintf("\t*%v_sz /= sizeof(**%v);", typ.TypeName, typ.TypeName),
@@ -170,7 +170,7 @@ func (q QFunc) GenDispatchCodeC(contractName string) string {
 		popStatement := getQtumPopStatement(input.Type)
 		if isArray(input.Type) {
 			statement = append(statement, getBaseType(input.Type)+"_t* "+input.TypeName+";")
-			statement = append(statement, "size_t "+input.TypeName+"_sz = qtumItemSize();")
+			statement = append(statement, "size_t "+input.TypeName+"_sz = qtumPeekSize();")
 			statement = append(statement, input.TypeName+" = malloc("+input.TypeName+"_sz);")
 			statement = append(statement, popStatement+"("+input.TypeName+", "+input.TypeName+"_sz);")
 		} else if input.Type == "uniaddress" {

--- a/definitions/definitions.go
+++ b/definitions/definitions.go
@@ -161,7 +161,7 @@ func (typ QType) generateFuncCallBody() []string {
 func (q QFunc) GenDispatchCodeC(contractName string) string {
 	var statement []string
 	if !q.Payable {
-		statement = append(statement, "if(qtumExec->value > 0) {")
+		statement = append(statement, "if(qtumExec->valueSent > 0) {")
 		statement = append(statement, "\tqtumError(\"nonpayable function\");")
 		statement = append(statement, "}")
 	}

--- a/generation/c_generator.go
+++ b/generation/c_generator.go
@@ -65,8 +65,8 @@ const headerEncodingTemplateImpl = `{{ $contractName := .ContractName }}
 #endif`
 
 const headerDecodingTemplateImpl = `{{ $contractName := .ContractName }}
-#ifndef {{$contractName}}ABI_H
-#define {{$contractName}}ABI_H
+#ifndef {{$contractName}}DISPATCHER_H
+#define {{$contractName}}DISPATCHER_H
 
 //Function IDs
 {{range .Functions}}#ifndef ID_{{$contractName}}_{{.FuncName}}


### PR DESCRIPTION
This fixes some issues with code generation that weren't caught, and some issues where the libqtum spec changed from under it. Changes include:

* Adding the size argument to dispatcher function calls when they include array inputs and outputs
* Update qtumExecData->value to the proper qtumExecData->valueSent
* Update qtumItemSize() to qtumPeekSize() to match changed libqtum
* Update #ifdef guarding on the header files to differ between the encoding and decoding generated header files
* Add _dispatch suffix to decoding functions so that encoding and decoding functions will not conflict with each other if both used in the same program
* Add const specifications to input arrays. This helps with compiler optimizations etc, but also makes it much simpler to determine which arguments are intended to be inputs and outputs 